### PR TITLE
fix: correct validation for new migration

### DIFF
--- a/views/new-migrate/migration-steps/index.tsx
+++ b/views/new-migrate/migration-steps/index.tsx
@@ -26,7 +26,7 @@ const schema = yup.object().shape({
   websiteLink: yup.string(),
   twitterLink: yup
     .string()
-    .matches(/^(https?:\/\/)?(www\.)?twitter\.com\/[a-zA-Z0-9_]{1,15}\/?$/i, 'Invalid Twitter URL')
+    .matches(/^(https?:\/\/)?(www\.)?(twitter\.com|x\.com)\/[a-zA-Z0-9_]{1,15}\/?$/i, 'Invalid Twitter URL')
     .required('Twitter URL is Required'),
 });
 


### PR DESCRIPTION
This PR addresses and fixes the bug that prevented users from proceeding to the next step after inputting a Twitter link with x.com. Now, users can input Twitter links with either twitter.com or x.com without encountering any issues.

**Changes Made**

- Updated the validation schema to accept both twitter.com and x.com URLs.
- Ensured that users can proceed with either domain in their Twitter links.